### PR TITLE
Expand syntax highlighting and add indent file

### DIFF
--- a/indent/ron.vim
+++ b/indent/ron.vim
@@ -1,0 +1,8 @@
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal cindent
+setlocal cinoptions=L0,(0,Ws,J1,j1,m1
+setlocal cinkeys=0{,0},!^F,o,O,0[,0]

--- a/syntax/ron.vim
+++ b/syntax/ron.vim
@@ -12,7 +12,13 @@ syn region ronStruct start="(" end=")" transparent fold
 syn region ronSeq start="\[" end="\]" transparent fold
 syn region ronMap start="{" end="}" transparent fold
 
+syn region ronAttribute start="#!\?\[" end="\]"
+
 syn region ronString oneline start=/"/ skip=/\\\\\|\\"/ end=/"/
+
+syn match ronIdentifier /\<[A-Z]\w*\s*\ze(/ display
+
+syn match ronKey /\<\w\+\ze:/ display
 
 syn match ronInteger /\<[+-]\=[0-9]\(_\=\d\)*\>/ display
 
@@ -31,5 +37,8 @@ hi def link ronFloat Float
 hi def link ronBoolean Boolean
 hi def link ronTodo Todo
 hi def link ronComment Comment
+hi def link ronAttribute PreProc
+hi def link ronIdentifier Identifier
+hi def link ronKey Keyword
 
 let b:current_syntax = "ron"


### PR DESCRIPTION
Adds syntax highlighting to struct names, attributes and map keys.

Also adds basic indent file based on cindent. It's not perfect, but it's better than the defaults without it.