### PR TITLE
Set indentation to 4 spaces by default

### DIFF
--- a/ftplugin/ron.vim
+++ b/ftplugin/ron.vim
@@ -8,6 +8,13 @@ set cpo&vim
 
 setlocal commentstring=//\ %s
 
+" Setup indentation to 4 spaces
+" To disable add the this line to your vim config
+" let g:ron_recommended_style = 0
+if get(g:, 'ron_recommended_style', 1)
+    setlocal tabstop=8 shiftwidth=4 softtabstop=4 expandtab
+endif
+
 " Add NERDCommenter delimiters
 let s:delims = { 'left': '//' }
 if exists('g:NERDDelimiterMap')


### PR DESCRIPTION
This commit change so that vim use 4 space indentation when editing `.ron` files. A user can skip setting the indentation by 
adding `let g:ron_recommended_style = 0`  to their `.vimrc`.

I bet that the [Rusty Object Notation](https://github.com/ron-rs/ron) file format does not really care about indentation, but humans in a rust mindset probably do. Setting up vim to use 4 space indentation makes for a consistent experience when working both in `.rs` and `.ron` files at the same time.

This change mimics how the rust vim plugin sets indentation in [ftplugin/rust.vim](https://github.com/rust-lang/rust.vim/blob/master/ftplugin/rust.vim#L48).