### PR TITLE
Disable hardcoded tabstop for ron

### DIFF
--- a/ftplugin/ron.vim
+++ b/ftplugin/ron.vim
@@ -12,7 +12,7 @@ setlocal commentstring=//\ %s
 " To disable add the this line to your vim config
 " let g:ron_recommended_style = 0
 if get(g:, 'ron_recommended_style', 1)
-    setlocal tabstop=8 shiftwidth=4 softtabstop=4 expandtab
+    setlocal shiftwidth=4 softtabstop=4 expandtab
 endif
 
 " Add NERDCommenter delimiters


### PR DESCRIPTION
I use `tabstop=4` in my `nvim` configuration. When I open `*.ron` files with hard tabs, `ron.vim` discards my setting and forces `tabstop=8`. I know that I can set `g:ron_recommended_style = 0` to mitigate this issue, but I think that it's not `ron.vim`'s job to mess with my `tabstop` settings in the first place.

See https://github.com/rust-lang/rust.vim/pull/436 for a very similar issue in `rust.vim` plugin.